### PR TITLE
Wrap the error message on latest addition.

### DIFF
--- a/_nova/failure_prepping_block_device.md
+++ b/_nova/failure_prepping_block_device.md
@@ -10,7 +10,9 @@ weight: 4
 When booting a new instance using 'Boot from image (creates a new volume)', you may experience the following error:
 
 {% highlight bash %}
-Failed to perform requested operation on instance "test-instance", the instance has an error status: Please try again later [Error: Build of instance c57f6717-a0fc-4c26-960a-66a958a4ba3d aborted: Failure prepping block device.].
+Failed to perform requested operation on instance "test-instance", the instance has an error
+status: Please try again later [Error: Build of instance c57f6717-a0fc-4c26-960a-66a958a4ba3d
+aborted: Failure prepping block device.].
 {% endhighlight %}
 
 This is caused by a known bug in Nova. To remedy this issue, you can do the following:


### PR DESCRIPTION
The error message wasn't wrapping, so the page looked bad.
