### PR TITLE
Update CentOS 6 from 6.7 to 6.8

### DIFF
--- a/_userguides/Cloud_Images_Provided_by_IBM.md
+++ b/_userguides/Cloud_Images_Provided_by_IBM.md
@@ -35,7 +35,7 @@ The IBM Blue Box Cloud in this release comes pre-populated with Cirros 0.3.3 x86
 
 You may upload and install separately-acquired operating system software, or you may provision any of the following operating system images that we make available to you as a virtual machine instance.  You are responsible to comply with all applicable operating system license terms and to acquire proper entitlements for each virtual machine instance.
 
-* CentOS 6.7 x86_64
+* CentOS 6.8 x86_64
 * CentOS 7.2 x86_64
 * Ubuntu Server 12.04 LTS x86_64
 * Ubuntu Server 14.04 LTS x86_64


### PR DESCRIPTION
Our image release notes for 3.0 release was published, so we need to update the image catalog in our doc of "User's Guide to Cloud Images" to reflect the latest image version.
