### PR TITLE
Fix broken link to OpenStack APIs Supported

### DIFF
--- a/_api/openstack-api-getting-started.md
+++ b/_api/openstack-api-getting-started.md
@@ -61,7 +61,7 @@ This command will return a list of all running instances in your project.
 
 [Installing OpenStack Command Line Clients](http://docs.openstack.org/user-guide/content/install_clients.html)
 
-[API Versions Supported](https://www.openstack.org/marketplace/hosted-private-clouds/blue-box/blue-box-cloud---private-cloud-as-a-service)
+[API Versions Supported](https://www.openstack.org/marketplace/hosted-private-clouds/blue-box/ibm-blue-box---private-cloud-as-a-service)
 
 [What To Do If You Get An ImportError: No module named xmlrpc_client When Running Nova Client on Mac OS X](https://github.com/major/supernova/issues/55#issuecomment-59891149">What To Do If You Get An ImportError: No module named xmlrpc_client When Running Nova Client on Mac OS X)
 


### PR DESCRIPTION
@LeslieLundquist Hey, I've fixed the broken link for "API Versions Supported" in this doc. However, the page it links to displays the old Blue Box logo... which brings me to 2 questions:
1. Would it be best to leave this link out for now, given the presence of our old logo?
2. Do you happen know who we can contact to update the logo on this page?

Thanks!
