### PR TITLE
Update neutron RBAC table

### DIFF
--- a/_keystone/Managing_Users_and_Projects.md
+++ b/_keystone/Managing_Users_and_Projects.md
@@ -123,7 +123,7 @@ Manage image cache | N | N | N
 Network Feature | cloud_admin | project_admin (within project) |  \_member\_
 --------------- | ----------- | ------------------------------ | -----------
 Create network  | Y | Y | Y
-Create shared network | N | N | N
+Create shared network | Y | N | N
 Update network  | Y | Y | Y (owner)
 Delete network  | Y | Y | Y (owner)
 Create port     | Y | Y | Y


### PR DESCRIPTION
RBAC table for neutron was outdated. `cloud_admin` is now able to create shared networks.
