### PR TITLE
Workaround for updating loadbalancer quota

### DIFF
--- a/_userdocs/quotas.md
+++ b/_userdocs/quotas.md
@@ -229,7 +229,7 @@ For example:
 ## How to list Tenant Network Quotas
 
 {% highlight bash %}
-# neutron quota-show --tenant-id <tenant-id> --user-id <user-id>
+# neutron quota-show --tenant-id <tenant-id>
 {% endhighlight %}
 
 For example:
@@ -252,7 +252,13 @@ For example:
 ## How to update Tenant Network Quotas
 
 {% highlight bash %}
-# neutron quota-update --tenant-id <tenant-id> --user-id <user-id> --<resource> <limit>
+# neutron quota-update --tenant-id <tenant-id> --<resource> <limit>
+{% endhighlight %}
+
+If Neutron LBaaS is enabled in your cluster, you may encounter a problem that the quota of `loadbalancer` can't be updated via above command when you are using `python-neutronclient` of version < `6.0.0` (there won't be any error from the command, but the quota limit will be unchanged), that is a bug in older version of `python-neutronclient` and had been fixed in version `6.0.0` and higher. Please upgrade your `python-neutronclient` or use the following command as a workaround solution for `python-neutronclient` of version < `6.0.0`.
+
+{% highlight bash %}
+# neutron quota-update <tenant-id> --loadbalancer <limit>
 {% endhighlight %}
 
 # Storage Quotas


### PR DESCRIPTION
Providing a workaround solution for a bug about updating loadbalancer quota in old version of python-neutronclient. Found in ops ticket: https://support.bluebox.net/tickets/B78AE3

And I also removed the `--user-id` option as I didn't see it in the current neutron CLI guide https://docs.openstack.org/cli-reference/neutron.html, and I also got following error when using it on our controller node of a cluster (salesdemo):
```
# neutron quota-update --tenant-id=f621247c355d4ce3bb689a84ea58d9f2 --user-id=bbe9e13cd5d54d329483d37cfbdbc336 --loadbalancer 15
Unrecognized attribute(s) 'user_id'
Neutron server returns request_ids: ['req-e8106a90-af88-4c16-8544-9275e99f5278']

# neutron quota-update --tenant-id=f621247c355d4ce3bb689a84ea58d9f2 --user-id=bbe9e13cd5d54d329483d37cfbdbc336 --pool 15
Unrecognized attribute(s) 'user_id'
Neutron server returns request_ids: ['req-c63ecf86-a34b-4bc0-922c-063861fc8611']
```